### PR TITLE
Introduce `DuplicateId` error variant for improved error handling

### DIFF
--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -18,6 +18,9 @@ pub enum Error {
   #[error("Argon2PasswordHash error: {0}")]
   Argon2PasswordHash(argon2::password_hash::Error),
 
+  #[error("Duplicate id '{0}': A password with this id already exists")]
+  DuplicateId(String),
+
   #[error("The password provided is empty")]
   EmptyPassword,
 

--- a/src/manager/tests.rs
+++ b/src/manager/tests.rs
@@ -95,8 +95,12 @@ fn test_special_character_password() {
 #[test]
 fn test_duplicate_password_addition() {
   let (manager, _temp_file) = setup_db();
-  manager.add_password("duplicate_id", "password").unwrap();
-  assert!(manager.add_password("duplicate_id", "password").is_err());
+  let duplicate_id = "duplicate_id";
+  manager.add_password(duplicate_id, "password").unwrap();
+  match manager.add_password(duplicate_id, "password") {
+    Err(Error::DuplicateId(id)) => assert_eq!(duplicate_id, id),
+    _ => panic!("Expected DuplicateId error"),
+  }
 }
 
 #[test]


### PR DESCRIPTION
Before this change, attempting to add a password when the ID already exists in the database will yield:

```
SQLite error: UNIQUE constraint failed: passwords.id
```

This is not very friendly for a non-SQL library.

Afterwards, we get:

```
Duplicate id '{}': A password with this id already exists
```

where `{}` is a placeholder for whatever ID was entered.