### PR TITLE
Add `found_signature()` method to `PwdManager`

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,15 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0
+*/
+use rusqlite::{Connection, Result};
+
+pub fn is_empty(conn: &Connection) -> Result<bool> {
+  conn
+    .query_row(
+      "SELECT exists (SELECT name FROM sqlite_master WHERE type = 'table')",
+      [],
+      |row| row.get(0),
+    )
+    .map(|x: u8| x == 0)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ Copyright 2024 Owain Davies
 SPDX-License-Identifier: Apache-2.0
 */
 #![doc = include_str!("../README.md")]
+mod db;
 mod manager;
 
 pub use manager::error::{Error, Result};

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -30,6 +30,9 @@ pub enum Error {
   #[error("No password found for the provided id")]
   PasswordNotFound,
 
+  #[error("pwdm signature not found in database")]
+  SignatureNotFound,
+
   #[error("SQLite error: {0}")]
   Sqlite(#[from] rusqlite::Error),
 

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
   #[error("No password found for the provided id")]
   PasswordNotFound,
 
-  #[error("pwdm signature not found in database")]
+  #[error("pwdm signature not found")]
   SignatureNotFound,
 
   #[error("SQLite error: {0}")]


### PR DESCRIPTION
A unique 'file signature' specific to `pwdm` has been introduced. The manager now cross-verifies this signature whenever a database connection is successfully opened, essentially confirming that the database has been originally configured by `pwdm`. This helps, for example, preventing any inadvertent operations on databases that are unknown to or have not been configured by `pwdm`. The 'file signature' is stored in the database.