### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "pwdm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwdm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Owain Davies"]


### PR DESCRIPTION
Changes include minor README updates and output formatting tweaks for the CLI.

- Removed install from source section in README.
- Noted that master password should be strong in README and how `pwdm` enforces that the password entered is not weak.
- Clear output before retry if passwords don't match when prompting for password plus confirmation.