### PR TITLE
Use service and username to identify each password

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rudimentary command-line tool and Rust library for managing passwords.
 ## Password Database
 
 Passwords are encrypted and stored in a SQLite database where each password is
-identified by a unique ID string.
+uniquely identified by a **service** name and an optional **username**.
 
 ## Security
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ mod db;
 mod manager;
 
 pub use manager::error::{Error, Result};
-pub use manager::PwdManager;
+pub use manager::{PwdManager, UserIdentity};

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -18,8 +18,8 @@ pub enum Error {
   #[error("Argon2PasswordHash error: {0}")]
   Argon2PasswordHash(argon2::password_hash::Error),
 
-  #[error("Duplicate id '{0}': A password with this id already exists")]
-  DuplicateId(String),
+  #[error("Duplicate user identity: A password with this uid already exists")]
+  DuplicateId(crate::manager::UserIdentity),
 
   #[error("The password provided is empty")]
   EmptyPassword,


### PR DESCRIPTION
Refactored the password manager to utilize a service-username pair (represented by the `UserIdentity` struct), rather than an ID string, to identify each password. This is more aligned with real-world user behavior, as users tend to associate a password with a username and a particular target platform, not with an arbitrary ID. This change makes the password manager easier to use.