### PR TITLE
Fix formatting issues in CLI "List" table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -318,8 +318,12 @@ fn list_passwords(pwd_manager: &PwdManager) -> Result<()> {
   if uids.is_empty() {
     println!("No passwords stored.");
   } else {
-    let max_service_len =
-      uids.iter().map(|uid| uid.service.len()).max().unwrap_or(0);
+    let max_service_len = uids
+      .iter()
+      .map(|uid| uid.service.len())
+      .max()
+      .unwrap_or(0)
+      .max("Service".len());
     let max_username_len = uids
       .iter()
       .filter_map(|uid| uid.username.as_ref().map(String::len))
@@ -327,6 +331,7 @@ fn list_passwords(pwd_manager: &PwdManager) -> Result<()> {
       .unwrap_or(0);
     let separator_len = " | ".len();
     let header_len = max_service_len + separator_len + "Username".len();
+
     println!(
       "\n{0:<pad$} | {1}",
       "Service".cyan(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,6 +325,8 @@ fn list_passwords(pwd_manager: &PwdManager) -> Result<()> {
       .filter_map(|uid| uid.username.as_ref().map(String::len))
       .max()
       .unwrap_or(0);
+    let separator_len = " | ".len();
+    let header_len = max_service_len + separator_len + "Username".len();
     println!(
       "\n{0:<pad$} | {1}",
       "Service".cyan(),
@@ -334,7 +336,10 @@ fn list_passwords(pwd_manager: &PwdManager) -> Result<()> {
     println!(
       "{:=<pad$}",
       "",
-      pad = max_service_len + max_username_len + 3
+      pad = std::cmp::max(
+        max_service_len + max_username_len + separator_len,
+        header_len
+      )
     );
     for uid in uids {
       println!(


### PR DESCRIPTION
This ensures that the border line (composed of '=' characters) under the header of the "List" table in the CLI is not shorter than the header text. The border line would be shorter, for example, if there is only a single entry with no username or a short username. Moreover, it ensures that when the service name is short, that the '|' separator for a (service, username) entry aligns with the header's '|'.